### PR TITLE
Get rid of warnings when building with recent gcc

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,6 +2,7 @@ Copyright (c) 2017-2018 Aalto University
 
 Authors:
 - Juha-Matti Tilli (copyright to Aalto University transferred on 19.4.2018)
+- Vladis Dronov (copyright to Aalto University transferred on 8.8.2018)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/log/log.c
+++ b/log/log.c
@@ -58,9 +58,9 @@ void log_impl_vlog(enum log_level level, const char *compname, const char *file,
 {
   struct timeval tv;
   struct tm tm;
-  char msgbuf[16384] = {0};
+  char msgbuf[16200] = {0};
   char linebuf[16384] = {0};
-  char timebuf[256] = {0};
+  char timebuf[64] = {0};
   const char *progname = globals.progname;
   int time_condition;
   int i;

--- a/tuntap/tuntap.c
+++ b/tuntap/tuntap.c
@@ -28,7 +28,7 @@ int tap_alloc(const char *devreq, char actual_dev[IFNAMSIZ])
   ifr.ifr_flags = IFF_TAP; 
   if (devreq && *devreq)
   {
-    strncpy(ifr.ifr_name, devreq, IFNAMSIZ);
+    strncpy(ifr.ifr_name, devreq, IFNAMSIZ-1);
   }
 
   err = ioctl(fd, TUNSETIFF, (void *)&ifr);
@@ -57,7 +57,7 @@ int tun_alloc(const char *devreq, char actual_dev[IFNAMSIZ])
   ifr.ifr_flags = IFF_TUN; 
   if (devreq && *devreq)
   {
-    strncpy(ifr.ifr_name, devreq, IFNAMSIZ);
+    strncpy(ifr.ifr_name, devreq, IFNAMSIZ-1);
   }
 
   err = ioctl(fd, TUNSETIFF, (void *)&ifr);


### PR DESCRIPTION
recent gcc spits warnings (treated as errors) about possible string truncations.

log/log.c: fix by making log prefix and msgbuf to fit into linebuf.
tuntap/tuntap.c: fix strncpy()'s by copying 1 byte less, leaving a place for \0. later snprintf() would cut ifr.ifr_name to IFNAMSIZ-1 bytes anyway.