### PR TITLE
No -Werror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ a.out
 perf.data
 perf.data.old
 /opts.mk
+/opts.smk
 /.stir.db

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ DIRLIBPPTK := libpptk
 LCLIBPPTK := libpptk
 MODULES += LIBPPTK
 
-CFLAGS := -g -O2 -Wall -Wextra -Wsign-conversion -Wno-missing-field-initializers -Wno-unused-parameter -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Werror -std=gnu11 -fPIC
+CFLAGS := -g -O2 -Wall -Wextra -Wsign-conversion -Wno-missing-field-initializers -Wno-unused-parameter -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -std=gnu11 -fPIC
 
 .PHONY: all clean distclean unit
 
@@ -135,6 +135,7 @@ unit: $(patsubst %,unit_%,$(MODULES))
 MAKEFILES_COMMON := Makefile opts.mk
 
 WITH_NETMAP=no
+WITH_WERROR=no
 NETMAP_INCDIR=
 WITH_ODP=no
 ODP_DIR=/usr/local
@@ -143,6 +144,10 @@ DDPK_INCDIR=
 DPDK_LIBDIR=
 LIBS_ODPDEP=/usr/lib/x86_64-linux-gnu/libssl.a /usr/lib/x86_64-linux-gnu/libcrypto.a
 include opts.mk
+
+ifeq ($(WITH_WERROR),yes)
+CFLAGS := $(CFLAGS) -Werror
+endif
 
 $(foreach module,$(MODULES),$(eval \
     include $(DIR$(module))/module.mk))

--- a/Stirfile
+++ b/Stirfile
@@ -4,8 +4,9 @@
 @fileinclude @ignore "opts.smk"
 
 # You can modify these for compilation
+$WITH_WERROR ?= @false
 $CC ?= "cc"
-$CFLAGS ?= ["-g", "-O2", "-Wall", "-Wextra", "-Wsign-conversion", "-Wno-missing-field-initializers", "-Wno-unused-parameter", "-Wshadow", "-Wstrict-prototypes", "-Wmissing-prototypes", "-Wpointer-arith", "-Werror", "-std=gnu11", "-fPIC"]
+$CFLAGS ?= ["-g", "-O2", "-Wall", "-Wextra", "-Wsign-conversion", "-Wno-missing-field-initializers", "-Wno-unused-parameter", "-Wshadow", "-Wstrict-prototypes", "-Wmissing-prototypes", "-Wpointer-arith", "-std=gnu11", "-fPIC"]
 $WITH_NETMAP ?= @false
 $NETMAP_INCDIR ?= ""
 $WITH_ODP ?= @false
@@ -16,6 +17,10 @@ $DPDK_INCDIR ?= ""
 $DPDK_LIBDIR ?= ""
 $LIBS_ODPDEP ?= ["/usr/lib/x86_64-linux-gnu/libssl.a", "/usr/lib/x86_64-linux-gnu/libcrypto.a"]
 $LDFLAGS ?= []
+
+@if($WITH_WERROR)
+  $CFLAGS = [@$CFLAGS, "-Werror"]
+@endif
 
 # You can modify these during development
 $MODS = ["tcpreass", "dynarr", "misc", "hashlist", "hashtable", "rbtree", "avltree", "timerrb", "timeravl", "linkedlist", "timerlinkheap", "timerskiplist", "timerwheel", "log", "iphdr", "ipfrag", "packet", "arp", "ports", "queue", "alloc", "random", "databuf", "tuntap", "portlist", "netmap", "iphash", "mypcap", "ldp", "libpptk"]


### PR DESCRIPTION
Make compiling without -Werror the default to make it easier to compile with newer compilers that detect more warnings. Also, add opts.smk to .gitignore.